### PR TITLE
chore: add dependabot config and pin docker dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,26 @@
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "semver:minor"
+    ignored_updates:
+      - match:
+          dependency_name: "django"
+          version_requirement: ">=3"
+    commit_message:
+      prefix: "chore"
+      include_scope: true
+    default_reviewers:
+      - "open-dynaMIX"
+  - package_manager: "docker"
+    directory: "/"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "chore"
+      include_scope: true
+    default_reviewers:
+      - "open-dynaMIX"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
-FROM python:3.6.9
-
+FROM python:3.6.10-slim-buster@sha256:6689433d2e67177976cf043501ed177f312af586a09071092ee65745a2a63ab4
 WORKDIR /app
 
-RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -P /usr/local/bin \
+RUN apt-get update && apt-get install -y --no-install-recommends libpq-dev wget build-essential \
+&& wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -P /usr/local/bin \
 && chmod +x /usr/local/bin/wait-for-it.sh \
 && mkdir -p /app \
 && useradd -u 901 -r emeis --create-home \
 # all project specific folders need to be accessible by newly created user but also for unknown users (when UID is set manually). Such users are in group root.
 && chown -R emeis:root /home/emeis \
 && chmod -R 770 /home/emeis
-
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  # needed for psycopg2
-  libpq-dev
 
 # needs to be set for users with manually set UID
 ENV HOME=/home/emeis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   db:
-    image: postgres:alpine
+    image: postgres:12.2-alpine@sha256:9ea72265275674225b1eaa2ae897dd244028af4ee7ef6e4e89fe474938e0992e
     environment:
       - POSTGRES_USER=emeis
       # following option is a must to configure on production system:
@@ -10,7 +10,7 @@ services:
     volumes:
       - dbdata:/var/lib/postgresql/data
   emeis:
-    image: projectcaluma/emeis
+    image: projectcaluma/emeis:latest
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
This commit also switches from the `python:3.6.9` base image to
`python:3.6.10-slim-buster`.