### PR TITLE
feat: Add `ALLOW_ANONYMOUS_WRITE` to settings

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -21,3 +21,4 @@ services:
       ]
     environment:
       - ENV=dev
+      - ALLOW_ANONYMOUS_WRITE=true

--- a/emeis/core/serializers.py
+++ b/emeis/core/serializers.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import AnonymousUser
 from rest_framework_json_api import serializers
 
 from .models import ACL, Permission, Role, Scope, User
@@ -10,7 +11,8 @@ class BaseSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         user = self.context["request"].user
-        validated_data["created_by_user"] = user
+        if not isinstance(user, AnonymousUser):
+            validated_data["created_by_user"] = user
 
         return super().create(validated_data)
 

--- a/emeis/core/tests/test_permissions.py
+++ b/emeis/core/tests/test_permissions.py
@@ -9,9 +9,20 @@ from rest_framework.status import (
 )
 
 from emeis.core.models import PermissionMixin, Scope, User
-from emeis.core.permissions import BasePermission, object_permission_for, permission_for
+from emeis.core.permissions import (
+    AllowAny,
+    BasePermission,
+    object_permission_for,
+    permission_for,
+)
 
 TIMESTAMP = "2017-05-21T11:25:41.123840Z"
+
+
+@pytest.fixture
+def reset_permission_classes():
+    yield
+    PermissionMixin.permission_classes = [AllowAny]
 
 
 @pytest.mark.freeze_time(TIMESTAMP)
@@ -25,7 +36,14 @@ TIMESTAMP = "2017-05-21T11:25:41.123840Z"
 )
 @pytest.mark.parametrize("use_admin_client", [True, False])
 def test_permission(
-    user_factory, admin_user, admin_client, client, method, status, use_admin_client,
+    user_factory,
+    admin_user,
+    admin_client,
+    client,
+    method,
+    status,
+    use_admin_client,
+    reset_permission_classes,
 ):
     client = admin_client if use_admin_client else client
 
@@ -90,7 +108,7 @@ def test_permission(
         assert user.username == "mark48"
 
 
-def test_permission_no_permissions_configured(client):
+def test_permission_no_permissions_configured(client, reset_permission_classes):
     PermissionMixin.permission_classes = None
 
     data = {

--- a/emeis/core/views.py
+++ b/emeis/core/views.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework.viewsets import GenericViewSet
@@ -27,6 +28,7 @@ class MeViewSet(RetrieveModelMixin, GenericViewSet):
     """Me view returns current user."""
 
     serializer_class = serializers.MeSerializer
+    permission_classes = [IsAuthenticated]
 
     def get_object(self, *args, **kwargs):
         return self.request.user
@@ -37,6 +39,7 @@ class MyACLViewSet(RetrieveModelMixin, ListModelMixin, GenericViewSet):
 
     queryset = models.ACL.objects.all()
     serializer_class = serializers.MyACLSerializer
+    permission_classes = [IsAuthenticated]
 
     def get_object(self):
         pk = self.kwargs.pop("pk")

--- a/emeis/settings.py
+++ b/emeis/settings.py
@@ -176,6 +176,15 @@ SIMPLE_AUTH = {
 }
 
 
+# Anonymous writing
+ALLOW_ANONYMOUS_WRITE = env.bool("ALLOW_ANONYMOUS_WRITE", default=False)
+
+if not ALLOW_ANONYMOUS_WRITE:  # pragma: no cover
+    REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = [
+        "rest_framework.permissions.IsAuthenticatedOrReadOnly",
+    ]
+
+
 def parse_admins(admins):
     """
     Parse env admins to django admins.


### PR DESCRIPTION
This commit adds a new `ALLOW_ANONYMOUS` settings that can be set via
envvar. This is particularly handy when interacting with emeis without
an OIDC provider (during setup or dev). As well as some cornercases,
where you actually want to anonymous users to write data.