### PR TITLE
feat(auth): introduce user factory setting and oidc user object

### DIFF
--- a/docs/extending_emeis.md
+++ b/docs/extending_emeis.md
@@ -1,0 +1,115 @@
+# Extending and embedding Emeis
+
+Emeis is used ideally as a stand-alone microservice. However, it also can be used
+as a Django app. When using Emeis as a standalone app, you can mount your own
+files into the container  and point to them via environment variables.
+
+
+## Extension points
+
+For customization some clear extension points are defined. In case a customization is needed
+where no extension point is defined, best [open an issue](https://github.com/projectcaluma/caluma/issues/new) for discussion.
+
+### Visibility classes
+
+The visibility part defines what you can see at all. Anything you cannot see, you're implicitly also not allowed to modify. The visibility classes define what you see depending on your roles, permissions, etc. Building on top of this follow the permission classes (see below) that define what you can do with the data you see.
+
+Visibility classes are configured as `VISIBILITY_CLASSES`.
+
+Following pre-defined classes are available:
+* `emeis.core.visibilities.Any`: Allow any user without any filtering
+* `emeis.core.visibilities.Union`: Union result of a list of configured visibility classes. May only be used as base class.
+* `emeis.user.visibilities.OwnAndAdmin`: Only show data that belongs to the current user. For admin show all data
+
+In case this default classes do not cover your use case, it is also possible to create your custom
+visibility class defining per node how to filter.
+
+Example:
+```python
+from emeis.core.visibilities import BaseVisibility, filter_queryset_for
+from emeis.core.models import BaseModel, Scope
+
+
+class CustomVisibility(BaseVisibility):
+    @filter_queryset_for(BaseModel)
+    def filter_queryset_for_all(self, queryset, request):
+        return queryset.filter(created_by_user=request.user.username)
+    @filter_queryset_for(Scope)
+    def filter_queryset_for_scope(self, queryset, request):
+        return queryset.exclude(slug='protected-scope')
+```
+
+Arguments:
+* `queryset`: [Queryset](https://docs.djangoproject.com/en/2.1/ref/models/querysets/) of specific node type
+* `request`: holds the [http request](https://docs.djangoproject.com/en/1.11/ref/request-response/#httprequest-objects)
+
+Save your visibility module as `visibilities.py` and inject it as Docker volume to path `/app/caluma/extensions/visibilities.py`,
+
+Afterwards you can configure it in `VISIBILITY_CLASSES` as `emeis.extensions.visibilities.CustomVisibility`.
+
+### Permission classes
+
+Permission classes define who may perform which data mutation. Such can be configured as `PERMISSION_CLASSES`.
+
+Following pre-defined classes are available:
+* `emeis.core.permissions.AllowAny`: allow any users to perform any mutation.
+
+In case this default classes do not cover your use case, it is also possible to create your custom
+permission class defining per mutation and mutation object what is allowed.
+
+Example:
+```python
+from emeis.core.permissions import BasePermission, object_permission_for, permission_for
+from emeis.core.models import BaseModel, User
+
+class CustomPermission(BasePermission):
+    @permission_for(BaseModel)
+    def has_permission_default(self, request):
+        # change default permission to False when no more specific
+        # permission is defined.
+        return False
+
+    @permission_for(User)
+    def has_permission_for_user(self, request):
+        return True
+
+    @object_permission_for(User)
+    def has_object_permission_for_user(self, request, instance):
+        return request.user.username == 'admin'
+```
+
+Arguments:
+* `request`: holds the [http request](https://docs.djangoproject.com/en/1.11/ref/request-response/#httprequest-objects)
+* `instance`: instance being edited by specific request
+
+Save your permission module as `permissions.py` and inject it as Docker volume to path `/app/caluma/extensions/permissions.py`,
+
+Afterwards you can configure it in `PERMISSION_CLASSES` as `emeis.extensions.permissions.CustomPermission`.
+
+
+### OIDC User factory
+
+Especially when using Emeis embedded in another Django project, you need to
+ensure compatibility with other components. By default, Emeis provides
+a "shim" user object in it's role as an OIDC relying party (RP) that represents
+the requesting user. It also points to the user model that stores that user
+in the database. Other projects may have other requirements however.
+
+Therefore, you can define a custom `EMEIS_OIDC_USER_FACTORY`. The setting is a string
+that points to a callable, which is expected to return an OIDC user object. By
+default it points to `emeis.oidc_auth.authentication.OIDCUser`.
+
+The factory is called with two arguments: First, the username, and second,
+a python dictionary containing the OIDC claims:
+
+```python
+    user_factory(username, claims)
+```
+
+The resulting object is expected to provide the following properties:
+* `username` - returns the username.
+* `user` - returns the user database model
+* `is_authenticated` - Boolean that should always be `True`
+
+You may extend the object  as you please, for example by providing shortcuts
+to data you need (such as visible Emeis claims, etc).

--- a/emeis/conftest.py
+++ b/emeis/conftest.py
@@ -3,6 +3,7 @@ import inspect
 
 import pytest
 from django.core.cache import cache
+from django.utils.module_loading import import_string
 from factory.base import FactoryMetaClass
 from pytest_factoryboy import register
 from rest_framework.test import APIClient
@@ -23,8 +24,12 @@ register_module(importlib.import_module(".core.factories", "emeis"))
 
 
 @pytest.fixture
-def admin_user(db, user_factory):
-    return user_factory(username="admin")
+def admin_user(db, user, settings):
+    user.username = "admin"
+    user.save()
+
+    user_factory = import_string(settings.EMEIS_OIDC_USER_FACTORY)
+    return user_factory("admin", {settings.OIDC_USERNAME_CLAIM: "admin"})
 
 
 @pytest.fixture

--- a/emeis/core/serializers.py
+++ b/emeis/core/serializers.py
@@ -12,7 +12,7 @@ class BaseSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         user = self.context["request"].user
         if not isinstance(user, AnonymousUser):
-            validated_data["created_by_user"] = user
+            validated_data["created_by_user"] = user.user
 
         return super().create(validated_data)
 

--- a/emeis/core/tests/snapshots/snap_test_api.py
+++ b/emeis/core/tests/snapshots/snap_test_api.py
@@ -7,6 +7,139 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots["test_api_list[RoleViewSet] 1"] = {
+    "queries": [
+        'SELECT "emeis_core_role"."created_at", "emeis_core_role"."modified_at", "emeis_core_role"."created_by_user_id", "emeis_core_role"."meta", "emeis_core_role"."slug", "emeis_core_role"."name", "emeis_core_role"."description" FROM "emeis_core_role" ORDER BY "emeis_core_role"."slug" ASC',
+        'SELECT ("emeis_core_role_permissions"."role_id") AS "_prefetch_related_val_role_id", "emeis_core_permission"."created_at", "emeis_core_permission"."modified_at", "emeis_core_permission"."created_by_user_id", "emeis_core_permission"."meta", "emeis_core_permission"."slug", "emeis_core_permission"."name", "emeis_core_permission"."description" FROM "emeis_core_permission" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_permission"."slug" = "emeis_core_role_permissions"."permission_id") WHERE "emeis_core_role_permissions"."role_id" IN (\'front-her-occur\', \'kid-owner-car\', \'note-act-source\', \'run-too-successful\')',
+        'SELECT "emeis_core_role"."created_at", "emeis_core_role"."modified_at", "emeis_core_role"."created_by_user_id", "emeis_core_role"."meta", "emeis_core_role"."slug", "emeis_core_role"."name", "emeis_core_role"."description" FROM "emeis_core_role" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_role"."slug" = "emeis_core_role_permissions"."role_id") WHERE "emeis_core_role_permissions"."permission_id" = \'program-small\' ORDER BY "emeis_core_role"."slug" ASC',
+    ],
+    "request": {
+        "CONTENT_TYPE": "application/octet-stream",
+        "PATH_INFO": "/api/v1/roles",
+        "QUERY_STRING": "include=permissions",
+        "REQUEST_METHOD": "GET",
+        "SERVER_PORT": "80",
+    },
+    "response": {
+        "data": [
+            {
+                "attributes": {
+                    "created-at": "2017-05-21T00:00:00Z",
+                    "description": {
+                        "de": "",
+                        "en": """Process truth assume popular contain commercial with. Detail race high even might.
+Thing summer prevent free environment measure role later. Capital direction capital Congress doctor land prevent.""",
+                        "fr": "",
+                    },
+                    "meta": {},
+                    "modified-at": "2017-05-21T00:00:00Z",
+                    "name": {"de": "", "en": "Linda Taylor", "fr": ""},
+                    "slug": "front-her-occur",
+                },
+                "id": "front-her-occur",
+                "relationships": {
+                    "created-by-user": {"data": None},
+                    "permissions": {"data": [], "meta": {"count": 0}},
+                },
+                "type": "roles",
+            },
+            {
+                "attributes": {
+                    "created-at": "2017-05-21T00:00:00Z",
+                    "description": {
+                        "de": "",
+                        "en": """Open else look tree arm responsibility week. Environmental statement bag someone them style.
+Public these health team change. Tax final upon stay sing middle suggest.""",
+                        "fr": "",
+                    },
+                    "meta": {},
+                    "modified-at": "2017-05-21T00:00:00Z",
+                    "name": {"de": "", "en": "Gregory Scott", "fr": ""},
+                    "slug": "kid-owner-car",
+                },
+                "id": "kid-owner-car",
+                "relationships": {
+                    "created-by-user": {"data": None},
+                    "permissions": {
+                        "data": [{"id": "program-small", "type": "permissions"}],
+                        "meta": {"count": 1},
+                    },
+                },
+                "type": "roles",
+            },
+            {
+                "attributes": {
+                    "created-at": "2017-05-21T00:00:00Z",
+                    "description": {
+                        "de": "",
+                        "en": """Far bit among again. Station story first. Team suggest traditional boy above.
+Central meeting anyone remember. There today material minute ago get. Range whose scientist draw free property consider.""",
+                        "fr": "",
+                    },
+                    "meta": {},
+                    "modified-at": "2017-05-21T00:00:00Z",
+                    "name": {"de": "", "en": "Erin Scott", "fr": ""},
+                    "slug": "note-act-source",
+                },
+                "id": "note-act-source",
+                "relationships": {
+                    "created-by-user": {"data": None},
+                    "permissions": {"data": [], "meta": {"count": 0}},
+                },
+                "type": "roles",
+            },
+            {
+                "attributes": {
+                    "created-at": "2017-05-21T00:00:00Z",
+                    "description": {
+                        "de": "",
+                        "en": """Arm serious live by itself. Project find white continue none president.
+Partner area media increase meeting article. Success provide beyond seek officer player.""",
+                        "fr": "",
+                    },
+                    "meta": {},
+                    "modified-at": "2017-05-21T00:00:00Z",
+                    "name": {"de": "", "en": "Timothy Malone", "fr": ""},
+                    "slug": "run-too-successful",
+                },
+                "id": "run-too-successful",
+                "relationships": {
+                    "created-by-user": {"data": None},
+                    "permissions": {"data": [], "meta": {"count": 0}},
+                },
+                "type": "roles",
+            },
+        ],
+        "included": [
+            {
+                "attributes": {
+                    "created-at": "2017-05-21T00:00:00Z",
+                    "description": {
+                        "de": "",
+                        "en": """Sound discover Mrs once long. Well treatment radio with Mr letter eye. Society street hair local kind debate line simple.
+Treat better note everybody party. Miss south speak industry.""",
+                        "fr": "",
+                    },
+                    "meta": {},
+                    "modified-at": "2017-05-21T00:00:00Z",
+                    "name": {"de": "", "en": "Denise Horton", "fr": ""},
+                    "slug": "program-small",
+                },
+                "id": "program-small",
+                "relationships": {
+                    "created-by-user": {"data": None},
+                    "roles": {
+                        "data": [{"id": "kid-owner-car", "type": "roles"}],
+                        "meta": {"count": 1},
+                    },
+                },
+                "type": "permissions",
+            }
+        ],
+    },
+    "status": 200,
+}
+
 snapshots["test_api_list[ACLViewSet] 1"] = {
     "queries": [
         'SELECT "emeis_core_acl"."created_at", "emeis_core_acl"."modified_at", "emeis_core_acl"."created_by_user_id", "emeis_core_acl"."meta", "emeis_core_acl"."id", "emeis_core_acl"."user_id", "emeis_core_acl"."scope_id", "emeis_core_acl"."role_id" FROM "emeis_core_acl"',
@@ -412,118 +545,6 @@ Thing summer prevent free environment measure role later. Capital direction capi
     "status": 200,
 }
 
-snapshots["test_api_list[RoleViewSet] 1"] = {
-    "queries": [
-        'SELECT "emeis_core_role"."created_at", "emeis_core_role"."modified_at", "emeis_core_role"."created_by_user_id", "emeis_core_role"."meta", "emeis_core_role"."slug", "emeis_core_role"."name", "emeis_core_role"."description" FROM "emeis_core_role" ORDER BY "emeis_core_role"."slug" ASC',
-        'SELECT ("emeis_core_role_permissions"."role_id") AS "_prefetch_related_val_role_id", "emeis_core_permission"."created_at", "emeis_core_permission"."modified_at", "emeis_core_permission"."created_by_user_id", "emeis_core_permission"."meta", "emeis_core_permission"."slug", "emeis_core_permission"."name", "emeis_core_permission"."description" FROM "emeis_core_permission" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_permission"."slug" = "emeis_core_role_permissions"."permission_id") WHERE "emeis_core_role_permissions"."role_id" IN (\'front-her-occur\', \'note-act-source\', \'run-too-successful\')',
-        'SELECT "emeis_core_role"."created_at", "emeis_core_role"."modified_at", "emeis_core_role"."created_by_user_id", "emeis_core_role"."meta", "emeis_core_role"."slug", "emeis_core_role"."name", "emeis_core_role"."description" FROM "emeis_core_role" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_role"."slug" = "emeis_core_role_permissions"."role_id") WHERE "emeis_core_role_permissions"."permission_id" = \'kid-owner-car\' ORDER BY "emeis_core_role"."slug" ASC',
-    ],
-    "request": {
-        "CONTENT_TYPE": "application/octet-stream",
-        "PATH_INFO": "/api/v1/roles",
-        "QUERY_STRING": "include=permissions",
-        "REQUEST_METHOD": "GET",
-        "SERVER_PORT": "80",
-    },
-    "response": {
-        "data": [
-            {
-                "attributes": {
-                    "created-at": "2017-05-21T00:00:00Z",
-                    "description": {
-                        "de": "",
-                        "en": """Process truth assume popular contain commercial with. Detail race high even might.
-Thing summer prevent free environment measure role later. Capital direction capital Congress doctor land prevent.""",
-                        "fr": "",
-                    },
-                    "meta": {},
-                    "modified-at": "2017-05-21T00:00:00Z",
-                    "name": {"de": "", "en": "Linda Taylor", "fr": ""},
-                    "slug": "front-her-occur",
-                },
-                "id": "front-her-occur",
-                "relationships": {
-                    "created-by-user": {"data": None},
-                    "permissions": {"data": [], "meta": {"count": 0}},
-                },
-                "type": "roles",
-            },
-            {
-                "attributes": {
-                    "created-at": "2017-05-21T00:00:00Z",
-                    "description": {
-                        "de": "",
-                        "en": """Far bit among again. Station story first. Team suggest traditional boy above.
-Central meeting anyone remember. There today material minute ago get. Range whose scientist draw free property consider.""",
-                        "fr": "",
-                    },
-                    "meta": {},
-                    "modified-at": "2017-05-21T00:00:00Z",
-                    "name": {"de": "", "en": "Erin Scott", "fr": ""},
-                    "slug": "note-act-source",
-                },
-                "id": "note-act-source",
-                "relationships": {
-                    "created-by-user": {"data": None},
-                    "permissions": {
-                        "data": [{"id": "kid-owner-car", "type": "permissions"}],
-                        "meta": {"count": 1},
-                    },
-                },
-                "type": "roles",
-            },
-            {
-                "attributes": {
-                    "created-at": "2017-05-21T00:00:00Z",
-                    "description": {
-                        "de": "",
-                        "en": """Arm serious live by itself. Project find white continue none president.
-Partner area media increase meeting article. Success provide beyond seek officer player.""",
-                        "fr": "",
-                    },
-                    "meta": {},
-                    "modified-at": "2017-05-21T00:00:00Z",
-                    "name": {"de": "", "en": "Timothy Malone", "fr": ""},
-                    "slug": "run-too-successful",
-                },
-                "id": "run-too-successful",
-                "relationships": {
-                    "created-by-user": {"data": None},
-                    "permissions": {"data": [], "meta": {"count": 0}},
-                },
-                "type": "roles",
-            },
-        ],
-        "included": [
-            {
-                "attributes": {
-                    "created-at": "2017-05-21T00:00:00Z",
-                    "description": {
-                        "de": "",
-                        "en": """Open else look tree arm responsibility week. Environmental statement bag someone them style.
-Public these health team change. Tax final upon stay sing middle suggest.""",
-                        "fr": "",
-                    },
-                    "meta": {},
-                    "modified-at": "2017-05-21T00:00:00Z",
-                    "name": {"de": "", "en": "Gregory Scott", "fr": ""},
-                    "slug": "kid-owner-car",
-                },
-                "id": "kid-owner-car",
-                "relationships": {
-                    "created-by-user": {"data": None},
-                    "roles": {
-                        "data": [{"id": "note-act-source", "type": "roles"}],
-                        "meta": {"count": 1},
-                    },
-                },
-                "type": "permissions",
-            }
-        ],
-    },
-    "status": 200,
-}
-
 snapshots["test_api_list[ScopeViewSet] 1"] = {
     "queries": [
         'SELECT "emeis_core_scope"."created_at", "emeis_core_scope"."modified_at", "emeis_core_scope"."created_by_user_id", "emeis_core_scope"."meta", "emeis_core_scope"."id", "emeis_core_scope"."name", "emeis_core_scope"."description", "emeis_core_scope"."parent_id", "emeis_core_scope"."lft", "emeis_core_scope"."rght", "emeis_core_scope"."tree_id", "emeis_core_scope"."level" FROM "emeis_core_scope" ORDER BY "emeis_core_scope"."tree_id" ASC, "emeis_core_scope"."lft" ASC'
@@ -650,7 +671,7 @@ snapshots["test_api_list[UserViewSet] 1"] = {
                     "city": {"de": "", "en": "", "fr": ""},
                     "created-at": "2017-05-21T00:00:00Z",
                     "date-joined": "2017-05-21T00:00:00Z",
-                    "email": "ealexander@example.org",
+                    "email": "fieldsjanice@example.net",
                     "first-name": "Natalie",
                     "is-active": True,
                     "language": "en",
@@ -884,7 +905,6 @@ snapshots["test_api_detail[RoleViewSet] 1"] = {
     "queries": [
         'SELECT "emeis_core_role"."created_at", "emeis_core_role"."modified_at", "emeis_core_role"."created_by_user_id", "emeis_core_role"."meta", "emeis_core_role"."slug", "emeis_core_role"."name", "emeis_core_role"."description" FROM "emeis_core_role" WHERE "emeis_core_role"."slug" = \'note-act-source\'',
         'SELECT ("emeis_core_role_permissions"."role_id") AS "_prefetch_related_val_role_id", "emeis_core_permission"."created_at", "emeis_core_permission"."modified_at", "emeis_core_permission"."created_by_user_id", "emeis_core_permission"."meta", "emeis_core_permission"."slug", "emeis_core_permission"."name", "emeis_core_permission"."description" FROM "emeis_core_permission" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_permission"."slug" = "emeis_core_role_permissions"."permission_id") WHERE "emeis_core_role_permissions"."role_id" IN (\'note-act-source\')',
-        'SELECT "emeis_core_role"."created_at", "emeis_core_role"."modified_at", "emeis_core_role"."created_by_user_id", "emeis_core_role"."meta", "emeis_core_role"."slug", "emeis_core_role"."name", "emeis_core_role"."description" FROM "emeis_core_role" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_role"."slug" = "emeis_core_role_permissions"."role_id") WHERE "emeis_core_role_permissions"."permission_id" = \'kid-owner-car\' ORDER BY "emeis_core_role"."slug" ASC',
     ],
     "request": {
         "CONTENT_TYPE": "application/octet-stream",
@@ -911,39 +931,10 @@ Central meeting anyone remember. There today material minute ago get. Range whos
             "id": "note-act-source",
             "relationships": {
                 "created-by-user": {"data": None},
-                "permissions": {
-                    "data": [{"id": "kid-owner-car", "type": "permissions"}],
-                    "meta": {"count": 1},
-                },
+                "permissions": {"data": [], "meta": {"count": 0}},
             },
             "type": "roles",
-        },
-        "included": [
-            {
-                "attributes": {
-                    "created-at": "2017-05-21T00:00:00Z",
-                    "description": {
-                        "de": "",
-                        "en": """Open else look tree arm responsibility week. Environmental statement bag someone them style.
-Public these health team change. Tax final upon stay sing middle suggest.""",
-                        "fr": "",
-                    },
-                    "meta": {},
-                    "modified-at": "2017-05-21T00:00:00Z",
-                    "name": {"de": "", "en": "Gregory Scott", "fr": ""},
-                    "slug": "kid-owner-car",
-                },
-                "id": "kid-owner-car",
-                "relationships": {
-                    "created-by-user": {"data": None},
-                    "roles": {
-                        "data": [{"id": "note-act-source", "type": "roles"}],
-                        "meta": {"count": 1},
-                    },
-                },
-                "type": "permissions",
-            }
-        ],
+        }
     },
     "status": 200,
 }
@@ -1024,250 +1015,6 @@ snapshots["test_api_detail[UserViewSet] 1"] = {
         }
     },
     "status": 200,
-}
-
-snapshots["test_api_create[ACLViewSet] 1"] = {
-    "queries": [
-        'SELECT "emeis_core_user"."password", "emeis_core_user"."last_login", "emeis_core_user"."created_at", "emeis_core_user"."modified_at", "emeis_core_user"."created_by_user_id", "emeis_core_user"."meta", "emeis_core_user"."id", "emeis_core_user"."username", "emeis_core_user"."first_name", "emeis_core_user"."last_name", "emeis_core_user"."email", "emeis_core_user"."phone", "emeis_core_user"."language", "emeis_core_user"."address", "emeis_core_user"."city", "emeis_core_user"."zip", "emeis_core_user"."is_active", "emeis_core_user"."date_joined" FROM "emeis_core_user" WHERE "emeis_core_user"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid',
-        'SELECT "emeis_core_scope"."created_at", "emeis_core_scope"."modified_at", "emeis_core_scope"."created_by_user_id", "emeis_core_scope"."meta", "emeis_core_scope"."id", "emeis_core_scope"."name", "emeis_core_scope"."description", "emeis_core_scope"."parent_id", "emeis_core_scope"."lft", "emeis_core_scope"."rght", "emeis_core_scope"."tree_id", "emeis_core_scope"."level" FROM "emeis_core_scope" WHERE "emeis_core_scope"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid',
-        'SELECT "emeis_core_role"."created_at", "emeis_core_role"."modified_at", "emeis_core_role"."created_by_user_id", "emeis_core_role"."meta", "emeis_core_role"."slug", "emeis_core_role"."name", "emeis_core_role"."description" FROM "emeis_core_role" WHERE "emeis_core_role"."slug" = \'fund-executive-most\'',
-        'SELECT (1) AS "a" FROM "emeis_core_acl" WHERE ("emeis_core_acl"."role_id" = \'fund-executive-most\' AND "emeis_core_acl"."scope_id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid AND "emeis_core_acl"."user_id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid)  LIMIT 1',
-        'INSERT INTO "emeis_core_acl" ("created_at", "modified_at", "created_by_user_id", "meta", "id", "user_id", "scope_id", "role_id") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid, \'{}\', \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid, \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid, \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid, \'fund-executive-most\')',
-    ],
-    "request": {
-        "CONTENT_LENGTH": "432",
-        "CONTENT_TYPE": "application/vnd.api+json",
-        "PATH_INFO": "/api/v1/acls",
-        "QUERY_STRING": "",
-        "REQUEST_METHOD": "POST",
-        "SERVER_PORT": "80",
-    },
-    "response": {
-        "data": {
-            "attributes": {
-                "created-at": "2017-05-21T00:00:00Z",
-                "meta": {},
-                "modified-at": "2017-05-21T00:00:00Z",
-            },
-            "id": "fb0e22c7-9ac7-5679-e988-1e6ba183b354",
-            "relationships": {
-                "created-by-user": {
-                    "data": {
-                        "id": "ea416ed0-759d-46a8-de58-f63a59077499",
-                        "type": "users",
-                    }
-                },
-                "role": {"data": {"id": "fund-executive-most", "type": "roles"}},
-                "scope": {
-                    "data": {
-                        "id": "9336ebf2-5087-d91c-818e-e6e9ec29f8c1",
-                        "type": "scopes",
-                    }
-                },
-                "user": {
-                    "data": {
-                        "id": "9dd4e461-268c-8034-f5c8-564e155c67a6",
-                        "type": "users",
-                    }
-                },
-            },
-            "type": "acls",
-        }
-    },
-    "status": 201,
-}
-
-snapshots["test_api_create[PermissionViewSet] 1"] = {
-    "queries": [
-        'SELECT (1) AS "a" FROM "emeis_core_permission" WHERE "emeis_core_permission"."slug" = \'note-act-source\'  LIMIT 1',
-        """INSERT INTO "emeis_core_permission" ("created_at", "modified_at", "created_by_user_id", "meta", "slug", "name", "description") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid, \'{}\', \'note-act-source\', hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Erin Scott\',\'\',\'\']), hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Far bit among again. Station story first. Team suggest traditional boy above.
-Central meeting anyone remember. There today material minute ago get. Range whose scientist draw free property consider.','','']))""",
-        'SELECT "emeis_core_role"."slug" FROM "emeis_core_role" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_role"."slug" = "emeis_core_role_permissions"."role_id") WHERE "emeis_core_role_permissions"."permission_id" = \'note-act-source\' ORDER BY "emeis_core_role"."slug" ASC',
-        'SELECT "emeis_core_role"."created_at", "emeis_core_role"."modified_at", "emeis_core_role"."created_by_user_id", "emeis_core_role"."meta", "emeis_core_role"."slug", "emeis_core_role"."name", "emeis_core_role"."description" FROM "emeis_core_role" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_role"."slug" = "emeis_core_role_permissions"."role_id") WHERE "emeis_core_role_permissions"."permission_id" = \'note-act-source\' ORDER BY "emeis_core_role"."slug" ASC',
-    ],
-    "request": {
-        "CONTENT_LENGTH": "548",
-        "CONTENT_TYPE": "application/vnd.api+json",
-        "PATH_INFO": "/api/v1/permissions",
-        "QUERY_STRING": "",
-        "REQUEST_METHOD": "POST",
-        "SERVER_PORT": "80",
-    },
-    "response": {
-        "data": {
-            "attributes": {
-                "created-at": "2017-05-21T00:00:00Z",
-                "description": {
-                    "de": "",
-                    "en": """Far bit among again. Station story first. Team suggest traditional boy above.
-Central meeting anyone remember. There today material minute ago get. Range whose scientist draw free property consider.""",
-                    "fr": "",
-                },
-                "meta": {},
-                "modified-at": "2017-05-21T00:00:00Z",
-                "name": {"de": "", "en": "Erin Scott", "fr": ""},
-                "slug": "note-act-source",
-            },
-            "id": "note-act-source",
-            "relationships": {
-                "created-by-user": {
-                    "data": {
-                        "id": "9dd4e461-268c-8034-f5c8-564e155c67a6",
-                        "type": "users",
-                    }
-                },
-                "roles": {"data": [], "meta": {"count": 0}},
-            },
-            "type": "permissions",
-        }
-    },
-    "status": 201,
-}
-
-snapshots["test_api_create[RoleViewSet] 1"] = {
-    "queries": [
-        'SELECT (1) AS "a" FROM "emeis_core_role" WHERE "emeis_core_role"."slug" = \'note-act-source\'  LIMIT 1',
-        'SELECT "emeis_core_permission"."created_at", "emeis_core_permission"."modified_at", "emeis_core_permission"."created_by_user_id", "emeis_core_permission"."meta", "emeis_core_permission"."slug", "emeis_core_permission"."name", "emeis_core_permission"."description" FROM "emeis_core_permission" WHERE "emeis_core_permission"."slug" = \'kid-owner-car\'',
-        """INSERT INTO "emeis_core_role" ("created_at", "modified_at", "created_by_user_id", "meta", "slug", "name", "description") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid, \'{}\', \'note-act-source\', hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Erin Scott\',\'\',\'\']), hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Far bit among again. Station story first. Team suggest traditional boy above.
-Central meeting anyone remember. There today material minute ago get. Range whose scientist draw free property consider.','','']))""",
-        'SELECT "emeis_core_permission"."slug" FROM "emeis_core_permission" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_permission"."slug" = "emeis_core_role_permissions"."permission_id") WHERE "emeis_core_role_permissions"."role_id" = \'note-act-source\'',
-        'SELECT "emeis_core_role_permissions"."permission_id" FROM "emeis_core_role_permissions" WHERE ("emeis_core_role_permissions"."permission_id" IN (\'kid-owner-car\') AND "emeis_core_role_permissions"."role_id" = \'note-act-source\')',
-        'INSERT INTO "emeis_core_role_permissions" ("role_id", "permission_id") VALUES (\'note-act-source\', \'kid-owner-car\') RETURNING "emeis_core_role_permissions"."id"',
-        'SELECT "emeis_core_permission"."created_at", "emeis_core_permission"."modified_at", "emeis_core_permission"."created_by_user_id", "emeis_core_permission"."meta", "emeis_core_permission"."slug", "emeis_core_permission"."name", "emeis_core_permission"."description" FROM "emeis_core_permission" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_permission"."slug" = "emeis_core_role_permissions"."permission_id") WHERE "emeis_core_role_permissions"."role_id" = \'note-act-source\'',
-    ],
-    "request": {
-        "CONTENT_LENGTH": "591",
-        "CONTENT_TYPE": "application/vnd.api+json",
-        "PATH_INFO": "/api/v1/roles",
-        "QUERY_STRING": "",
-        "REQUEST_METHOD": "POST",
-        "SERVER_PORT": "80",
-    },
-    "response": {
-        "data": {
-            "attributes": {
-                "created-at": "2017-05-21T00:00:00Z",
-                "description": {
-                    "de": "",
-                    "en": """Far bit among again. Station story first. Team suggest traditional boy above.
-Central meeting anyone remember. There today material minute ago get. Range whose scientist draw free property consider.""",
-                    "fr": "",
-                },
-                "meta": {},
-                "modified-at": "2017-05-21T00:00:00Z",
-                "name": {"de": "", "en": "Erin Scott", "fr": ""},
-                "slug": "note-act-source",
-            },
-            "id": "note-act-source",
-            "relationships": {
-                "created-by-user": {
-                    "data": {
-                        "id": "9dd4e461-268c-8034-f5c8-564e155c67a6",
-                        "type": "users",
-                    }
-                },
-                "permissions": {
-                    "data": [{"id": "kid-owner-car", "type": "permissions"}],
-                    "meta": {"count": 1},
-                },
-            },
-            "type": "roles",
-        }
-    },
-    "status": 201,
-}
-
-snapshots["test_api_create[ScopeViewSet] 1"] = {
-    "queries": [
-        'SELECT MAX("emeis_core_scope"."tree_id") AS "tree_id__max" FROM "emeis_core_scope"',
-        """INSERT INTO "emeis_core_scope" ("created_at", "modified_at", "created_by_user_id", "meta", "id", "name", "description", "parent_id", "lft", "rght", "tree_id", "level") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid, \'{}\', \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid, hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Pamela Horton\',\'\',\'\']), hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Effort meet relationship far. Option program interesting station. First where during teach country talk across.
-Argue move appear catch toward help wind. Material minute ago get.','','']), NULL, 1, 2, 1, 0)""",
-    ],
-    "request": {
-        "CONTENT_LENGTH": "516",
-        "CONTENT_TYPE": "application/vnd.api+json",
-        "PATH_INFO": "/api/v1/scopes",
-        "QUERY_STRING": "",
-        "REQUEST_METHOD": "POST",
-        "SERVER_PORT": "80",
-    },
-    "response": {
-        "data": {
-            "attributes": {
-                "created-at": "2017-05-21T00:00:00Z",
-                "description": {
-                    "de": "",
-                    "en": """Effort meet relationship far. Option program interesting station. First where during teach country talk across.
-Argue move appear catch toward help wind. Material minute ago get.""",
-                    "fr": "",
-                },
-                "level": 0,
-                "meta": {},
-                "modified-at": "2017-05-21T00:00:00Z",
-                "name": {"de": "", "en": "Pamela Horton", "fr": ""},
-            },
-            "id": "f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad",
-            "relationships": {
-                "created-by-user": {
-                    "data": {
-                        "id": "9336ebf2-5087-d91c-818e-e6e9ec29f8c1",
-                        "type": "users",
-                    }
-                },
-                "parent": {"data": None},
-            },
-            "type": "scopes",
-        }
-    },
-    "status": 201,
-}
-
-snapshots["test_api_create[UserViewSet] 1"] = {
-    "queries": [
-        'SELECT (1) AS "a" FROM "emeis_core_user" WHERE "emeis_core_user"."username" = \'mark48\'  LIMIT 1',
-        'INSERT INTO "emeis_core_user" ("password", "last_login", "created_at", "modified_at", "created_by_user_id", "meta", "id", "username", "first_name", "last_name", "email", "phone", "language", "address", "city", "zip", "is_active", "date_joined") VALUES (\'\', NULL, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid, \'{}\', \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid, \'mark48\', \'Amanda\', \'Gallagher\', \'kennethgarcia@example.org\', NULL, \'en\', NULL, hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'\',\'\',\'\']), NULL, true, \'2017-05-21T00:00:00+00:00\'::timestamptz)',
-        'SELECT "emeis_core_acl"."created_at", "emeis_core_acl"."modified_at", "emeis_core_acl"."created_by_user_id", "emeis_core_acl"."meta", "emeis_core_acl"."id", "emeis_core_acl"."user_id", "emeis_core_acl"."scope_id", "emeis_core_acl"."role_id" FROM "emeis_core_acl" WHERE "emeis_core_acl"."user_id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid',
-    ],
-    "request": {
-        "CONTENT_LENGTH": "499",
-        "CONTENT_TYPE": "application/vnd.api+json",
-        "PATH_INFO": "/api/v1/users",
-        "QUERY_STRING": "",
-        "REQUEST_METHOD": "POST",
-        "SERVER_PORT": "80",
-    },
-    "response": {
-        "data": {
-            "attributes": {
-                "address": None,
-                "city": {"de": "", "en": "", "fr": ""},
-                "created-at": "2017-05-21T00:00:00Z",
-                "date-joined": "2017-05-21T00:00:00Z",
-                "email": "kennethgarcia@example.org",
-                "first-name": "Amanda",
-                "is-active": True,
-                "language": "en",
-                "last-name": "Gallagher",
-                "meta": {},
-                "modified-at": "2017-05-21T00:00:00Z",
-                "phone": None,
-                "username": "mark48",
-                "zip": None,
-            },
-            "id": "f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad",
-            "relationships": {
-                "acls": {"data": [], "meta": {"count": 0}},
-                "created-by-user": {
-                    "data": {
-                        "id": "9336ebf2-5087-d91c-818e-e6e9ec29f8c1",
-                        "type": "users",
-                    }
-                },
-            },
-            "type": "users",
-        }
-    },
-    "status": 201,
 }
 
 snapshots["test_api_patch[ACLViewSet] 1"] = {
@@ -1365,14 +1112,13 @@ snapshots["test_api_patch[RoleViewSet] 1"] = {
     "queries": [
         'SELECT "emeis_core_role"."created_at", "emeis_core_role"."modified_at", "emeis_core_role"."created_by_user_id", "emeis_core_role"."meta", "emeis_core_role"."slug", "emeis_core_role"."name", "emeis_core_role"."description" FROM "emeis_core_role" WHERE "emeis_core_role"."slug" = \'note-act-source\'',
         'SELECT (1) AS "a" FROM "emeis_core_role" WHERE ("emeis_core_role"."slug" = \'note-act-source\' AND NOT ("emeis_core_role"."slug" = \'note-act-source\'))  LIMIT 1',
-        'SELECT "emeis_core_permission"."created_at", "emeis_core_permission"."modified_at", "emeis_core_permission"."created_by_user_id", "emeis_core_permission"."meta", "emeis_core_permission"."slug", "emeis_core_permission"."name", "emeis_core_permission"."description" FROM "emeis_core_permission" WHERE "emeis_core_permission"."slug" = \'kid-owner-car\'',
         """UPDATE "emeis_core_role" SET "created_at" = \'2017-05-21T00:00:00+00:00\'::timestamptz, "modified_at" = \'2017-05-21T00:00:00+00:00\'::timestamptz, "created_by_user_id" = NULL, "meta" = \'{}\', "name" = hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Erin Scott\',\'\',\'\']), "description" = hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Far bit among again. Station story first. Team suggest traditional boy above.
 Central meeting anyone remember. There today material minute ago get. Range whose scientist draw free property consider.\',\'\',\'\']) WHERE "emeis_core_role"."slug" = \'note-act-source\'""",
         'SELECT "emeis_core_permission"."slug" FROM "emeis_core_permission" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_permission"."slug" = "emeis_core_role_permissions"."permission_id") WHERE "emeis_core_role_permissions"."role_id" = \'note-act-source\'',
         'SELECT "emeis_core_permission"."created_at", "emeis_core_permission"."modified_at", "emeis_core_permission"."created_by_user_id", "emeis_core_permission"."meta", "emeis_core_permission"."slug", "emeis_core_permission"."name", "emeis_core_permission"."description" FROM "emeis_core_permission" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_permission"."slug" = "emeis_core_role_permissions"."permission_id") WHERE "emeis_core_role_permissions"."role_id" = \'note-act-source\'',
     ],
     "request": {
-        "CONTENT_LENGTH": "591",
+        "CONTENT_LENGTH": "548",
         "CONTENT_TYPE": "application/vnd.api+json",
         "PATH_INFO": "/api/v1/roles/note-act-source",
         "QUERY_STRING": "",
@@ -1397,10 +1143,7 @@ Central meeting anyone remember. There today material minute ago get. Range whos
             "id": "note-act-source",
             "relationships": {
                 "created-by-user": {"data": None},
-                "permissions": {
-                    "data": [{"id": "kid-owner-car", "type": "permissions"}],
-                    "meta": {"count": 1},
-                },
+                "permissions": {"data": [], "meta": {"count": 0}},
             },
             "type": "roles",
         }
@@ -1585,4 +1328,242 @@ snapshots["test_api_destroy[UserViewSet] 1"] = {
         "SERVER_PORT": "80",
     },
     "status": 204,
+}
+
+snapshots["test_api_create[ACLViewSet] 1"] = {
+    "queries": [
+        'SELECT "emeis_core_user"."password", "emeis_core_user"."last_login", "emeis_core_user"."created_at", "emeis_core_user"."modified_at", "emeis_core_user"."created_by_user_id", "emeis_core_user"."meta", "emeis_core_user"."id", "emeis_core_user"."username", "emeis_core_user"."first_name", "emeis_core_user"."last_name", "emeis_core_user"."email", "emeis_core_user"."phone", "emeis_core_user"."language", "emeis_core_user"."address", "emeis_core_user"."city", "emeis_core_user"."zip", "emeis_core_user"."is_active", "emeis_core_user"."date_joined" FROM "emeis_core_user" WHERE "emeis_core_user"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid',
+        'SELECT "emeis_core_scope"."created_at", "emeis_core_scope"."modified_at", "emeis_core_scope"."created_by_user_id", "emeis_core_scope"."meta", "emeis_core_scope"."id", "emeis_core_scope"."name", "emeis_core_scope"."description", "emeis_core_scope"."parent_id", "emeis_core_scope"."lft", "emeis_core_scope"."rght", "emeis_core_scope"."tree_id", "emeis_core_scope"."level" FROM "emeis_core_scope" WHERE "emeis_core_scope"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid',
+        'SELECT "emeis_core_role"."created_at", "emeis_core_role"."modified_at", "emeis_core_role"."created_by_user_id", "emeis_core_role"."meta", "emeis_core_role"."slug", "emeis_core_role"."name", "emeis_core_role"."description" FROM "emeis_core_role" WHERE "emeis_core_role"."slug" = \'fund-executive-most\'',
+        'SELECT (1) AS "a" FROM "emeis_core_acl" WHERE ("emeis_core_acl"."role_id" = \'fund-executive-most\' AND "emeis_core_acl"."scope_id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid AND "emeis_core_acl"."user_id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid)  LIMIT 1',
+        'INSERT INTO "emeis_core_acl" ("created_at", "modified_at", "created_by_user_id", "meta", "id", "user_id", "scope_id", "role_id") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid, \'{}\', \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid, \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid, \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid, \'fund-executive-most\')',
+    ],
+    "request": {
+        "CONTENT_LENGTH": "432",
+        "CONTENT_TYPE": "application/vnd.api+json",
+        "PATH_INFO": "/api/v1/acls",
+        "QUERY_STRING": "",
+        "REQUEST_METHOD": "POST",
+        "SERVER_PORT": "80",
+    },
+    "response": {
+        "data": {
+            "attributes": {
+                "created-at": "2017-05-21T00:00:00Z",
+                "meta": {},
+                "modified-at": "2017-05-21T00:00:00Z",
+            },
+            "id": "fb0e22c7-9ac7-5679-e988-1e6ba183b354",
+            "relationships": {
+                "created-by-user": {
+                    "data": {
+                        "id": "ea416ed0-759d-46a8-de58-f63a59077499",
+                        "type": "users",
+                    }
+                },
+                "role": {"data": {"id": "fund-executive-most", "type": "roles"}},
+                "scope": {
+                    "data": {
+                        "id": "9336ebf2-5087-d91c-818e-e6e9ec29f8c1",
+                        "type": "scopes",
+                    }
+                },
+                "user": {
+                    "data": {
+                        "id": "9dd4e461-268c-8034-f5c8-564e155c67a6",
+                        "type": "users",
+                    }
+                },
+            },
+            "type": "acls",
+        }
+    },
+    "status": 201,
+}
+
+snapshots["test_api_create[PermissionViewSet] 1"] = {
+    "queries": [
+        'SELECT (1) AS "a" FROM "emeis_core_permission" WHERE "emeis_core_permission"."slug" = \'note-act-source\'  LIMIT 1',
+        """INSERT INTO "emeis_core_permission" ("created_at", "modified_at", "created_by_user_id", "meta", "slug", "name", "description") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid, \'{}\', \'note-act-source\', hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Erin Scott\',\'\',\'\']), hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Far bit among again. Station story first. Team suggest traditional boy above.
+Central meeting anyone remember. There today material minute ago get. Range whose scientist draw free property consider.','','']))""",
+        'SELECT "emeis_core_role"."slug" FROM "emeis_core_role" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_role"."slug" = "emeis_core_role_permissions"."role_id") WHERE "emeis_core_role_permissions"."permission_id" = \'note-act-source\' ORDER BY "emeis_core_role"."slug" ASC',
+        'SELECT "emeis_core_role"."created_at", "emeis_core_role"."modified_at", "emeis_core_role"."created_by_user_id", "emeis_core_role"."meta", "emeis_core_role"."slug", "emeis_core_role"."name", "emeis_core_role"."description" FROM "emeis_core_role" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_role"."slug" = "emeis_core_role_permissions"."role_id") WHERE "emeis_core_role_permissions"."permission_id" = \'note-act-source\' ORDER BY "emeis_core_role"."slug" ASC',
+    ],
+    "request": {
+        "CONTENT_LENGTH": "548",
+        "CONTENT_TYPE": "application/vnd.api+json",
+        "PATH_INFO": "/api/v1/permissions",
+        "QUERY_STRING": "",
+        "REQUEST_METHOD": "POST",
+        "SERVER_PORT": "80",
+    },
+    "response": {
+        "data": {
+            "attributes": {
+                "created-at": "2017-05-21T00:00:00Z",
+                "description": {
+                    "de": "",
+                    "en": """Far bit among again. Station story first. Team suggest traditional boy above.
+Central meeting anyone remember. There today material minute ago get. Range whose scientist draw free property consider.""",
+                    "fr": "",
+                },
+                "meta": {},
+                "modified-at": "2017-05-21T00:00:00Z",
+                "name": {"de": "", "en": "Erin Scott", "fr": ""},
+                "slug": "note-act-source",
+            },
+            "id": "note-act-source",
+            "relationships": {
+                "created-by-user": {
+                    "data": {
+                        "id": "9dd4e461-268c-8034-f5c8-564e155c67a6",
+                        "type": "users",
+                    }
+                },
+                "roles": {"data": [], "meta": {"count": 0}},
+            },
+            "type": "permissions",
+        }
+    },
+    "status": 201,
+}
+
+snapshots["test_api_create[RoleViewSet] 1"] = {
+    "queries": [
+        'SELECT (1) AS "a" FROM "emeis_core_role" WHERE "emeis_core_role"."slug" = \'note-act-source\'  LIMIT 1',
+        """INSERT INTO "emeis_core_role" ("created_at", "modified_at", "created_by_user_id", "meta", "slug", "name", "description") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid, \'{}\', \'note-act-source\', hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Erin Scott\',\'\',\'\']), hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Far bit among again. Station story first. Team suggest traditional boy above.
+Central meeting anyone remember. There today material minute ago get. Range whose scientist draw free property consider.','','']))""",
+        'SELECT "emeis_core_permission"."slug" FROM "emeis_core_permission" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_permission"."slug" = "emeis_core_role_permissions"."permission_id") WHERE "emeis_core_role_permissions"."role_id" = \'note-act-source\'',
+        'SELECT "emeis_core_permission"."created_at", "emeis_core_permission"."modified_at", "emeis_core_permission"."created_by_user_id", "emeis_core_permission"."meta", "emeis_core_permission"."slug", "emeis_core_permission"."name", "emeis_core_permission"."description" FROM "emeis_core_permission" INNER JOIN "emeis_core_role_permissions" ON ("emeis_core_permission"."slug" = "emeis_core_role_permissions"."permission_id") WHERE "emeis_core_role_permissions"."role_id" = \'note-act-source\'',
+    ],
+    "request": {
+        "CONTENT_LENGTH": "548",
+        "CONTENT_TYPE": "application/vnd.api+json",
+        "PATH_INFO": "/api/v1/roles",
+        "QUERY_STRING": "",
+        "REQUEST_METHOD": "POST",
+        "SERVER_PORT": "80",
+    },
+    "response": {
+        "data": {
+            "attributes": {
+                "created-at": "2017-05-21T00:00:00Z",
+                "description": {
+                    "de": "",
+                    "en": """Far bit among again. Station story first. Team suggest traditional boy above.
+Central meeting anyone remember. There today material minute ago get. Range whose scientist draw free property consider.""",
+                    "fr": "",
+                },
+                "meta": {},
+                "modified-at": "2017-05-21T00:00:00Z",
+                "name": {"de": "", "en": "Erin Scott", "fr": ""},
+                "slug": "note-act-source",
+            },
+            "id": "note-act-source",
+            "relationships": {
+                "created-by-user": {
+                    "data": {
+                        "id": "9dd4e461-268c-8034-f5c8-564e155c67a6",
+                        "type": "users",
+                    }
+                },
+                "permissions": {"data": [], "meta": {"count": 0}},
+            },
+            "type": "roles",
+        }
+    },
+    "status": 201,
+}
+
+snapshots["test_api_create[ScopeViewSet] 1"] = {
+    "queries": [
+        'SELECT MAX("emeis_core_scope"."tree_id") AS "tree_id__max" FROM "emeis_core_scope"',
+        """INSERT INTO "emeis_core_scope" ("created_at", "modified_at", "created_by_user_id", "meta", "id", "name", "description", "parent_id", "lft", "rght", "tree_id", "level") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid, \'{}\', \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid, hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Pamela Horton\',\'\',\'\']), hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'Effort meet relationship far. Option program interesting station. First where during teach country talk across.
+Argue move appear catch toward help wind. Material minute ago get.','','']), NULL, 1, 2, 1, 0)""",
+    ],
+    "request": {
+        "CONTENT_LENGTH": "516",
+        "CONTENT_TYPE": "application/vnd.api+json",
+        "PATH_INFO": "/api/v1/scopes",
+        "QUERY_STRING": "",
+        "REQUEST_METHOD": "POST",
+        "SERVER_PORT": "80",
+    },
+    "response": {
+        "data": {
+            "attributes": {
+                "created-at": "2017-05-21T00:00:00Z",
+                "description": {
+                    "de": "",
+                    "en": """Effort meet relationship far. Option program interesting station. First where during teach country talk across.
+Argue move appear catch toward help wind. Material minute ago get.""",
+                    "fr": "",
+                },
+                "level": 0,
+                "meta": {},
+                "modified-at": "2017-05-21T00:00:00Z",
+                "name": {"de": "", "en": "Pamela Horton", "fr": ""},
+            },
+            "id": "f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad",
+            "relationships": {
+                "created-by-user": {
+                    "data": {
+                        "id": "9336ebf2-5087-d91c-818e-e6e9ec29f8c1",
+                        "type": "users",
+                    }
+                },
+                "parent": {"data": None},
+            },
+            "type": "scopes",
+        }
+    },
+    "status": 201,
+}
+
+snapshots["test_api_create[UserViewSet] 1"] = {
+    "queries": [
+        'SELECT (1) AS "a" FROM "emeis_core_user" WHERE "emeis_core_user"."username" = \'mark48\'  LIMIT 1',
+        'INSERT INTO "emeis_core_user" ("password", "last_login", "created_at", "modified_at", "created_by_user_id", "meta", "id", "username", "first_name", "last_name", "email", "phone", "language", "address", "city", "zip", "is_active", "date_joined") VALUES (\'\', NULL, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'2017-05-21T00:00:00+00:00\'::timestamptz, \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid, \'{}\', \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid, \'mark48\', \'Amanda\', \'Gallagher\', \'kennethgarcia@example.org\', NULL, \'en\', NULL, hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'\',\'\',\'\']), NULL, true, \'2017-05-21T00:00:00+00:00\'::timestamptz)',
+        'SELECT "emeis_core_acl"."created_at", "emeis_core_acl"."modified_at", "emeis_core_acl"."created_by_user_id", "emeis_core_acl"."meta", "emeis_core_acl"."id", "emeis_core_acl"."user_id", "emeis_core_acl"."scope_id", "emeis_core_acl"."role_id" FROM "emeis_core_acl" WHERE "emeis_core_acl"."user_id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid',
+    ],
+    "request": {
+        "CONTENT_LENGTH": "499",
+        "CONTENT_TYPE": "application/vnd.api+json",
+        "PATH_INFO": "/api/v1/users",
+        "QUERY_STRING": "",
+        "REQUEST_METHOD": "POST",
+        "SERVER_PORT": "80",
+    },
+    "response": {
+        "data": {
+            "attributes": {
+                "address": None,
+                "city": {"de": "", "en": "", "fr": ""},
+                "created-at": "2017-05-21T00:00:00Z",
+                "date-joined": "2017-05-21T00:00:00Z",
+                "email": "kennethgarcia@example.org",
+                "first-name": "Amanda",
+                "is-active": True,
+                "language": "en",
+                "last-name": "Gallagher",
+                "meta": {},
+                "modified-at": "2017-05-21T00:00:00Z",
+                "phone": None,
+                "username": "mark48",
+                "zip": None,
+            },
+            "id": "f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad",
+            "relationships": {
+                "acls": {"data": [], "meta": {"count": 0}},
+                "created-by-user": {
+                    "data": {
+                        "id": "9336ebf2-5087-d91c-818e-e6e9ec29f8c1",
+                        "type": "users",
+                    }
+                },
+            },
+            "type": "users",
+        }
+    },
+    "status": 201,
 }

--- a/emeis/core/tests/test_visibility.py
+++ b/emeis/core/tests/test_visibility.py
@@ -19,6 +19,7 @@ from emeis.core.visibilities import (
     Union,
     filter_queryset_for,
 )
+from emeis.oidc_auth.authentication import OIDCUser
 
 
 @pytest.mark.parametrize("detail", [True, False])
@@ -245,10 +246,10 @@ def test_own_and_admin_visibility(
     request.user = AnonymousUser()
     expected_count = 0
     if requesting_user == "admin":
-        request.user = admin_user
+        request.user = OIDCUser(admin_user.username, {"sub": admin_user.username})
         expected_count = 2
     elif requesting_user == "user":
-        request.user = user
+        request.user = OIDCUser(user.username, {"sub": user.username})
         expected_count = 1
 
     scope1 = scope_factory()
@@ -263,7 +264,7 @@ def test_own_and_admin_visibility(
     role1.permissions.add(perm1)
 
     acl_factory(user=user, scope=scope1, role=role1)
-    acl_factory(user=admin_user, scope=scope2, role=role2)
+    acl_factory(user=admin_user.user, scope=scope2, role=role2)
 
     result = OwnAndAdmin().filter_queryset(User, User.objects, request)
     assert result.count() == expected_count

--- a/emeis/core/visibilities.py
+++ b/emeis/core/visibilities.py
@@ -74,30 +74,32 @@ class Any(BaseVisibility):
 
 class OwnAndAdmin(BaseVisibility):
     @staticmethod
-    def generic_own_and_admin(request, queryset, filters=None, none=False):
+    def generic_own_and_admin(request, queryset, _filters_cb=lambda: {}, none=False):
         if isinstance(request.user, AnonymousUser):
             return queryset.none()
         elif request.user.username == settings.ADMIN_USERNAME:
             return queryset
         if none:
             return queryset.none()
-        return queryset.filter(**filters)
+        return queryset.filter(**_filters_cb())
 
     @filter_queryset_for(models.User)
     def filter_queryset_for_user(self, queryset, request):
-        return self.generic_own_and_admin(request, queryset, {"pk": request.user.pk})
+        return self.generic_own_and_admin(
+            request, queryset, lambda: {"pk": request.user.user.pk}
+        )
 
     @filter_queryset_for(models.Scope)
     @filter_queryset_for(models.Role)
     def filter_queryset_for_scope_and_role(self, queryset, request):
         return self.generic_own_and_admin(
-            request, queryset, {"acls__user": request.user.pk}
+            request, queryset, lambda: {"acls__user": request.user.user.pk}
         )
 
     @filter_queryset_for(models.Permission)
     def filter_queryset_for_permission(self, queryset, request):
         return self.generic_own_and_admin(
-            request, queryset, {"roles__acls__user": request.user.pk}
+            request, queryset, lambda: {"roles__acls__user": request.user.user.pk}
         )
 
     @filter_queryset_for(models.ACL)

--- a/emeis/oidc_auth/tests/test_authentication.py
+++ b/emeis/oidc_auth/tests/test_authentication.py
@@ -89,7 +89,7 @@ def test_authentication_new_user(
     except AuthenticationFailed:
         assert not create_user
     else:
-        assert user.email == email
+        assert user.user.email == email
 
     assert user_model.objects.count() == expected_count
 
@@ -113,7 +113,7 @@ def test_authentication_email_update(
     request = rf.get("/openid", HTTP_AUTHORIZATION="Bearer Token")
 
     user, _ = OIDCAuthentication().authenticate(request)
-    assert user.email == expected_email
+    assert user.user.email == expected_email
 
 
 def test_authentication_idp_502(

--- a/emeis/settings.py
+++ b/emeis/settings.py
@@ -134,6 +134,10 @@ OIDC_RP_CLIENT_ID = env.str("OIDC_RP_CLIENT_ID", default=None)
 OIDC_RP_CLIENT_SECRET = env.str("OIDC_RP_CLIENT_SECRET", default=None)
 OIDC_DRF_AUTH_BACKEND = "emeis.oidc_auth.authentication.EmeisAuthenticationBackend"
 
+EMEIS_OIDC_USER_FACTORY = env.str(
+    "EMEIS_OIDC_USER_FACTORY", default="emeis.oidc_auth.authentication.OIDCUser"
+)
+
 REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "rest_framework_json_api.exceptions.exception_handler",
     "DEFAULT_PAGINATION_CLASS": "rest_framework_json_api.pagination.JsonApiPageNumberPagination",


### PR DESCRIPTION
In OIDC RP projects such as this, we should not use an user model directly
to represent a user in a request. Instead, we use a proxy object (OIDCUser)
to represent the entity doing the request.

This is mainly done for compatibility with other projects that do it the same
way. They may or may not share the same user model.

To facilitate compatibility even further, we introduce a setting named
EMEIS_OIDC_USER_FACTORY, which can be overwritten via environment variables
if the need arises.