### PR TITLE
chore: better model stringification

### DIFF
--- a/emeis/core/tests/test_models.py
+++ b/emeis/core/tests/test_models.py
@@ -54,3 +54,14 @@ def test_can_authenticate(db, user):
         request, username=user.username, password="test_password"
     )
     assert auth == user
+
+
+def test_scope_hierarchical_name(scope_factory):
+    root = scope_factory()
+    child = scope_factory(parent=root)
+    grandchild = scope_factory(parent=child)
+
+    assert (
+        grandchild.full_name(sep=">")
+        == f"{root.name} > {child.name} > {grandchild.name}"
+    )


### PR DESCRIPTION
The model stringifications were a bit too verbose for my taste. Make
them output a bit more user-friendly names: A bit more compact than
before, and in case of ACLs, a bit more useful information as well.
The scopes now output hierarchical names instead of plain PKs