### PR TITLE
feat(search): enable forcing models to be monolingual in search

### DIFF
--- a/emeis/core/views.py
+++ b/emeis/core/views.py
@@ -64,6 +64,9 @@ class UserViewSet(BaseViewset):
         "=zip",
         "city",
     )
+    multilingual_search_fields = [
+        "city",
+    ]
 
     case_insensitive_ordering_fields = [
         "first_name",
@@ -126,6 +129,11 @@ class ScopeViewSet(BaseViewset):
         "name",
         "description",
     )
+    multilingual_search_fields = [
+        "name",
+        "description",
+    ]
+
     case_insensitive_ordering_fields = [
         "name",
         "description",
@@ -140,6 +148,11 @@ class RoleViewSet(BaseViewset):
         "name",
         "description",
     )
+    multilingual_search_fields = [
+        "name",
+        "description",
+    ]
+
     case_insensitive_ordering_fields = [
         "name",
         "description",
@@ -155,6 +168,10 @@ class PermissionViewSet(BaseViewset):
         "name",
         "description",
     )
+    multilingual_search_fields = [
+        "name",
+        "description",
+    ]
     case_insensitive_ordering_fields = [
         "name",
         "description",
@@ -176,3 +193,11 @@ class ACLViewSet(BaseViewset):
         "=user__zip",
         "user__city",
     )
+
+    multilingual_search_fields = [
+        "scope__name",
+        "scope__description",
+        "role__name",
+        "role__description",
+        "user__city",
+    ]

--- a/emeis/settings.py
+++ b/emeis/settings.py
@@ -147,6 +147,21 @@ LANGUAGES = (
 )
 LOCALE_PATHS = env.list("LOCALE_PATHS", default=[django_root("emeis", "locale")])
 
+# Force models to be monolingual despite them having
+# multilingual fields. This causes searches to use a "fixed"
+# locale instead of the currently-selected one. Note that
+# you MUST set the corresponding setting in ember-emeis as well
+# as it will then store the values in a "fixed" locale as well.
+#
+# If set via env var, set EMEIS_FORCE_MODEL_LOCALE=user:de,scope:de,...
+# where the model names must be lowercase
+EMEIS_FORCE_MODEL_LOCALE = {
+    model: lang
+    for path in env.list("EMEIS_FORCE_MODEL_LOCALE", default=[])
+    for model, lang in path.split(":")
+}
+
+
 TIME_ZONE = env.str("TIME_ZONE", "UTC")
 USE_I18N = True
 USE_L10N = True
@@ -198,7 +213,7 @@ REST_FRAMEWORK = {
         "rest_framework_json_api.filters.QueryParameterValidationFilter",
         "emeis.core.filters.CaseInsensitiveOrderingFilter",
         "rest_framework_json_api.django_filters.DjangoFilterBackend",
-        "rest_framework.filters.SearchFilter",
+        "emeis.core.filters.MonolingualSearchFilter",
     ),
     "SEARCH_PARAM": "filter[search]",
     "ORDERING_PARAM": "sort",


### PR DESCRIPTION
When users can manage models, they normally only enter data in a single
language.  When people with other language settings then search the same
data, the lookup will happen in the searching user's locale, which will
not return the desired results.

For such cases, we allow forcing a model to a given, fixed,
language. Then, the search on these models will always use the same
language.

This corresponds to a similar change in ember-emeis (our frontend), where
the setting forces the code to store data in the fixed language. Together,
this can then be used to make a multilingual model behave just as it
were monolingual.