### PR TITLE
chore(deps): downgrade werkzeug from 2.1.1 to 2.0.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,4 +28,4 @@ pytest-randomly==3.11.0
 python-semantic-release==7.27.1
 requests-mock==1.9.3
 snapshottest==0.6.0
-werkzeug==2.1.1
+werkzeug==2.0.3


### PR DESCRIPTION
since version 2.1.0 werkzeug isn't compatible with django-extensions, see:
https://github.com/django-extensions/django-extensions/issues/1715