### PR TITLE
chore(dependabot): allow dependabot to update docker image up to Python 3.10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,8 @@ updates:
   ignore:
   - dependency-name: python
     versions:
-    - ">=3.7"
+    # Django 3.2 LTS only supports Python up to 3.10
+    - ">3.10"
   commit-message:
     prefix: chore
     include: scope


### PR DESCRIPTION
This should enable dependabot to update the `FROM` in the `Dockerfile` to a more recent version.