### PR TITLE
ci: remove gitlint job from test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,20 +17,3 @@ jobs:
         run: make lint
       - name: Run test suite
         run: make test
-  commit-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install gitlint
-        run: pip install gitlint
-      - name: Run gitlint
-        run: |
-          gitlint --commits "origin/${{ github.base_ref }}..HEAD" \
-                  --contrib contrib-title-conventional-commits \
-                  --ignore B1,B5,B6


### PR DESCRIPTION
it's annoying and pretty useless like this. Let's consider setting up pre-commit lint instead like we do with all our other projects.